### PR TITLE
refactor(CmdHandler): Use the builder patterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,11 @@
 //! }
 //!
 //! fn main() {
-//!     let mut handler = CmdHandler::new();
-//!     handler.add(Box::new(CmdBuild));
-//!     handler.add(Box::new(CmdClean));
-//!     handler.parse();
+//!     CmdHandler::new()
+//!                .set_description("Rust's package manager.")
+//!                .add(Box::new(CmdBuild))
+//!                .add(Box::new(CmdClean))
+//!                .run();
 //! }
 //! ```
 


### PR DESCRIPTION
CmdHandler now use the builder patterns. See
`https://aturon.github.io/ownership/builders.html` for more info about
this patterns

BREAKING CHANGE: CmdHandler configuration now use the builder pattern

Close #16